### PR TITLE
Encode all non-alphanumeric characters to ensure compatibility with PHP's urlencode

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -9,8 +9,16 @@ TinyCertManagement = require('./cert.js');
 var TinyCertSession = function TinyCertSession(apiKey) {
     var sessionToken = null;
 
+    var encode = function encode(val) {
+        var transform = function transform(ch) {
+            return '%' + ch.charCodeAt(0).toString(16).toUpperCase();
+        }
+
+        return encodeURIComponent(val).toString().replace(/([^a-zA-Z0-9-_.%])/g, transform).replace(/%20/g, '+');
+    }
+
     var stringifyURIComponent = function stringifyURIComponent(key, val) {
-        return encodeURIComponent(key).toString().replace('%20', '+') + '=' + encodeURIComponent(val).toString().replace('%20', '+');
+        return encode(key) + '=' + encode(val);
     }
 
     /* Sign the parametrized target and construct query URI 


### PR DESCRIPTION
Fixes #2. I tried to follow the coding standard you already have in place. Please let me know if something needs fixing.
